### PR TITLE
admin 페이지 게시글 수 8개로 조정

### DIFF
--- a/carbonlease/src/main/java/com/kh/admin/activity/model/service/AdminActivityServiceImpl.java
+++ b/carbonlease/src/main/java/com/kh/admin/activity/model/service/AdminActivityServiceImpl.java
@@ -33,7 +33,7 @@ public class AdminActivityServiceImpl implements AdminActivityService {
 
         int count = mapper.getAdminCount(page, status, keyword);
 
-        Map<String, Object> params = pagination.pageRequest(page, 10, count);
+        Map<String, Object> params = pagination.pageRequest(page, 8, count);
         params.put("status", status);
         params.put("keyword", keyword);
 

--- a/carbonlease/src/main/java/com/kh/admin/board/model/service/AdminBoardServiceImpl.java
+++ b/carbonlease/src/main/java/com/kh/admin/board/model/service/AdminBoardServiceImpl.java
@@ -35,7 +35,7 @@ public class AdminBoardServiceImpl implements AdminBoardService {
 
         int count = mapper.getAdminBoardCount(params);
 
-        params = pagination.pageRequest(page, 10, count);
+        params = pagination.pageRequest(page, 8, count);
         params.put("status", status);
         params.put("keyword", keyword);
 


### PR DESCRIPTION
작업자 : 백준걸
작업일시 : 12/8
작업내용
- 기존 인증게시판, 일반게시판 관리자 페이지 게시글 목록 10 -> 8 조정